### PR TITLE
chore: change from pre-commit to pre-push validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "coverage": "aegir coverage",
     "coverage-publish": "aegir coverage --provider coveralls"
   },
-  "pre-commit": [
+  "pre-push": [
     "lint",
     "test"
   ],
@@ -46,13 +46,12 @@
     "traverse": "~0.6.6"
   },
   "devDependencies": {
-    "aegir": "^12.1.3",
+    "aegir": "^12.4.0",
     "chai": "^4.1.2",
     "deep-freeze": "0.0.1",
     "dirty-chai": "^2.0.1",
     "garbage": "0.0.0",
-    "ipfs-block": "~0.6.1",
-    "pre-commit": "^1.2.2"
+    "ipfs-block": "~0.6.1"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",


### PR DESCRIPTION
Instead of running lint and test before every commit, run it before
every push.