### PR TITLE
fix: use binary blobs directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "chai": "^4.1.2",
     "deep-freeze": "0.0.1",
     "dirty-chai": "^2.0.1",
-    "garbage": "0.0.0",
-    "ipfs-block": "~0.6.1"
+    "garbage": "0.0.0"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -14,13 +14,13 @@ const personInfoPaths = [
   'date'
 ]
 
-exports.resolve = (block, path, callback) => {
+exports.resolve = (binaryBlob, path, callback) => {
   if (typeof path === 'function') {
     callback = path
     path = undefined
   }
 
-  util.deserialize(block.data, (err, node) => {
+  util.deserialize(binaryBlob, (err, node) => {
     if (err) {
       return callback(err)
     }
@@ -76,7 +76,7 @@ exports.resolve = (block, path, callback) => {
   })
 }
 
-exports.tree = (block, options, callback) => {
+exports.tree = (binaryBlob, options, callback) => {
   if (typeof options === 'function') {
     callback = options
     options = undefined
@@ -84,7 +84,7 @@ exports.tree = (block, options, callback) => {
 
   options = options || {}
 
-  util.deserialize(block.data, (err, node) => {
+  util.deserialize(binaryBlob, (err, node) => {
     if (err) {
       return callback(err)
     }
@@ -133,8 +133,8 @@ exports.tree = (block, options, callback) => {
   })
 }
 
-exports.isLink = (block, path, callback) => {
-  exports.resolve(block, path, (err, result) => {
+exports.isLink = (binaryBlob, path, callback) => {
+  exports.resolve(binaryBlob, path, (err, result) => {
     if (err) {
       return callback(err)
     }


### PR DESCRIPTION
IPLD shouldn't need to know about IPFS. Hence work directly with
the binary data instead of using an IPFS block.

This is part of https://github.com/ipld/interface-ipld-format/issues/21

BREAKING CHANGE: Everyone calling the functions of `resolve` need to
pass in the binary data instead of an IPFS block.

So if your input is an IPFS block, the code changes from

    resolver.resolve(block, path, (err, result) => {…}

to

    resolver.resolve(block.data, path, (err, result) => {…}