### PR TITLE
chore: add module Lead Maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 
 > JavaScript implementation of the [IPLD spec](https://github.com/ipfs/specs/tree/master/ipld).
 
+## Lead Maintainer
+
+[Volker Mische](https://github.com/vmx)
+
 ## Table of Contents
 
 - [Install](#install)
@@ -22,7 +26,6 @@
   - [Use in a browser with browserify, webpack or any other bundler](#use-in-a-browser-with-browserify-webpack-or-any-other-bundler)
   - [Use in a browser Using a script tag](#use-in-a-browser-using-a-script-tag)
 - [Usage](#usage)
-- [Maintainers](#maintainers)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -65,10 +68,6 @@ const Git = require('ipld-git')
 
 // TODO
 ```
-
-## Maintainers
-
-[@magik6k](https://github.com/magik6k)
 
 ## Contribute
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ipld-git",
   "version": "0.2.0",
   "description": "JavaScript Implementation of Git IPLD format",
+  "leadMaintainer": "Volker Mische <volker.mische@gmail.com>",
   "main": "src/index.js",
   "scripts": {
     "test": "aegir test",
@@ -26,7 +27,6 @@
   "keywords": [
     "IPFS"
   ],
-  "author": "Lukasz Magiera <lmagiera@protonmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/ipld/js-ipld-git/issues"


### PR DESCRIPTION
The Guidelines for the InterPlanetary JavaScript Projects [1] specify
that there is one Lead Maintainer for every module. This commit add
that information to the repository.

[1]: https://github.com/ipfs/community/blob/master/js-code-guidelines.md