### PR TITLE
fix: pass serialized blob to util.cid

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const assert = require('assert')
 const setImmediate = require('async/setImmediate')
 const waterfall = require('async/waterfall')
 const multihashing = require('multihashing-async')
@@ -77,20 +78,20 @@ exports.deserialize = (data, callback) => {
 /**
  * Get the CID of the DAG-Node.
  *
- * @param {Object} dagNode - Internal representation
+ * @param {Buffer} blob - Serialized binary data
  * @param {Object} [options] - Ignored
  * @param {CidCallback} callback - Callback that handles the return value
  * @returns {void}
  */
-exports.cid = (dagNode, options, callback) => {
+exports.cid = (blob, options, callback) => {
+  assert(Buffer.isBuffer(blob), 'blob must be a Buffer')
   if (typeof options === 'function') {
     callback = options
     options = {}
   }
   options = options || {}
   waterfall([
-    (cb) => exports.serialize(dagNode, cb),
-    (serialized, cb) => multihashing(serialized, resolver.defaultHashAlg, cb),
+    (cb) => multihashing(blob, resolver.defaultHashAlg, cb),
     (mh, cb) => cb(null, new CID(1, resolver.multicodec, mh))
   ], callback)
 }

--- a/src/util.js
+++ b/src/util.js
@@ -76,9 +76,9 @@ exports.deserialize = (data, callback) => {
  * @param {?CID} cid - CID if call was successful
  */
 /**
- * Get the CID of the DAG-Node.
+ * Get the CID of the serialized Git node.
  *
- * @param {Buffer} blob - Serialized binary data
+ * @param {Buffer} blob - Serialized Git node
  * @param {Object} [options] - Ignored
  * @param {CidCallback} callback - Callback that handles the return value
  * @returns {void}

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -90,7 +90,7 @@ describe('git object parsing', () => {
 
           let expCid = util.shaToCid(Buffer.from(object[0], 'hex'))
 
-          ipldGit.util.cid(node, (err, cid) => {
+          ipldGit.util.cid(object[1], (err, cid) => {
             expect(err).to.not.exist()
             expect(cid).to.exist()
 

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -22,11 +22,13 @@ describe('IPLD format util', () => {
     },
     message: 'A message\n'
   }
+  let tagNodeSerialized
 
   it('.serialize and .deserialize', (done) => {
     ipldGit.util.serialize(tagNode, (err, serialized) => {
       expect(err).to.not.exist()
       expect(Buffer.isBuffer(serialized)).to.equal(true)
+      tagNodeSerialized = serialized
       ipldGit.util.deserialize(serialized, (err, deserialized) => {
         expect(err).to.not.exist()
         expect(tagNode).to.eql(deserialized)
@@ -36,7 +38,7 @@ describe('IPLD format util', () => {
   })
 
   it('.cid', (done) => {
-    ipldGit.util.cid(tagNode, (err, cid) => {
+    ipldGit.util.cid(tagNodeSerialized, (err, cid) => {
       expect(err).to.not.exist()
       expect(cid.version).to.equal(1)
       expect(cid.codec).to.equal('git-raw')
@@ -48,7 +50,7 @@ describe('IPLD format util', () => {
   })
 
   it('.cid ignores options', (done) => {
-    ipldGit.util.cid(tagNode, { hashAlg: 'unknown' }, (err, cid) => {
+    ipldGit.util.cid(tagNodeSerialized, { hashAlg: 'unknown' }, (err, cid) => {
       expect(err).to.not.exist()
       expect(cid.version).to.equal(1)
       expect(cid.codec).to.equal('git-raw')


### PR DESCRIPTION
BREAKING CHANGE: the first argument is now the serialized output NOT the dag node.
See https://github.com/ipld/interface-ipld-format/issues/32