### PR TITLE
Create usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,15 @@ Loading this module through a script tag will make the `IpldGit` obj available i
 
 ```JavaScript
 const IpldGit = require('ipld-git')
+const zlib = require('zlib')
 
-// TODO
+// `gitObject` is a Buffer containing a git object
+inflatedObject = zlib.inflateSync(gitObject)
+IpldGit.util.deserialize(inflatedObject, (err, dagNode) => {
+  if (err) throw err
+  console.log(dagNode)
+})
+
 ```
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 ### Use in Node.js
 
 ```JavaScript
-const Git = require('ipld-git')
+const IpldGit = require('ipld-git')
 ```
 
 ### Use in a browser with browserify, webpack or any other bundler
@@ -48,7 +48,7 @@ const Git = require('ipld-git')
 The code published to npm that gets loaded on require is in fact a ES5 transpiled version with the right shims added. This means that you can require it and use with your favourite bundler without having to adjust asset management process.
 
 ```JavaScript
-var Git = require('ipld-git')
+var IpldGit = require('ipld-git')
 ```
 
 ### Use in a browser Using a script tag
@@ -64,7 +64,7 @@ Loading this module through a script tag will make the `IpldGit` obj available i
 ## Usage
 
 ```JavaScript
-const Git = require('ipld-git')
+const IpldGit = require('ipld-git')
 
 // TODO
 ```


### PR DESCRIPTION
fixes #5 

I also changed it to require this package as `IpldGit` rather than just `Git` for consistency with other js-ipld-* repos 