### PR TITLE
refactor: default to CID v1 and encode with base32

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/ipld/js-ipld-git",
   "dependencies": {
     "async": "^2.6.0",
-    "cids": "~0.5.2",
+    "cids": "github:multiformats/js-cid#refactor/cidv1base32-default",
     "multicodec": "~0.4.0",
     "multihashes": "~0.4.12",
     "multihashing-async": "~0.5.1",


### PR DESCRIPTION
BREAKING CHANGE: Any CIDs created by this module are base32 encoded by default when stringified.

Depends on:

* [ ] https://github.com/multiformats/js-cid/pull/73