### PR TITLE
feat: use RFC3339 to format dates, fixes ipfs/go-ipld-git#16

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "multihashes": "~0.4.12",
     "multihashing-async": "~0.5.1",
     "smart-buffer": "^4.0.0",
-    "traverse": "~0.6.6"
+    "traverse": "~0.6.6",
+    "strftime": "~0.10.0"
   },
   "devDependencies": {
     "aegir": "^18.0.2",

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -22,7 +22,7 @@ describe('utils', () => {
       expect(info).to.exist()
       expect(info.name).to.equal('Someone')
       expect(info.email).to.equal('some@one.somewhere')
-      expect(info.date).to.equal('123456 +0123')
+      expect(info.date).to.equal('1970-01-02T11:40:36+01:23')
       done()
     })
 
@@ -31,7 +31,7 @@ describe('utils', () => {
       expect(info).to.exist()
       expect(info.name).to.equal('So Me One')
       expect(info.email).to.equal('some@one.somewhere')
-      expect(info.date).to.equal('123456 +0123')
+      expect(info.date).to.equal('1970-01-02T11:40:36+01:23')
       done()
     })
 
@@ -40,7 +40,7 @@ describe('utils', () => {
       expect(info).to.exist()
       expect(info.name).to.not.exist()
       expect(info.email).to.equal('some@one.somewhere')
-      expect(info.date).to.equal('123456 +0123')
+      expect(info.date).to.equal('1970-01-02T11:40:36+01:23')
       done()
     })
 
@@ -49,7 +49,7 @@ describe('utils', () => {
       expect(info).to.exist()
       expect(info.name).to.not.exist()
       expect(info.email).to.equal('some@one.somewhere')
-      expect(info.date).to.equal('123456 +0123')
+      expect(info.date).to.equal('1970-01-02T11:40:36+01:23')
       done()
     })
 
@@ -58,7 +58,7 @@ describe('utils', () => {
       expect(info).to.exist()
       expect(info.name).to.equal('Some One & Other One')
       expect(info.email).to.equal('some@one.somewhere, other@one.elsewhere')
-      expect(info.date).to.equal('987654 +4321')
+      expect(info.date).to.equal('1970-01-14T05:41:54+43:21')
       done()
     })
 

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -30,12 +30,12 @@ describe('IPLD format resolver (local)', () => {
       author: {
         name: 'John Doe',
         email: 'johndoe@example.com',
-        date: '1497302532 +0200'
+        date: '2017-06-12T23:22:12+02:00'
       },
       committer: {
         name: 'John Doe',
         email: 'johndoe@example.com',
-        date: '1497302532 +0200'
+        date: '2017-06-12T23:22:12+02:00'
       },
       encoding: 'ISO-8859-1',
       message: 'Encoded\n'
@@ -49,7 +49,7 @@ describe('IPLD format resolver (local)', () => {
       tagger: {
         name: 'John Doe',
         email: 'johndoe@example.com',
-        date: '1497302532 +0200'
+        date: '2017-06-12T23:22:12+02:00'
       },
       message: 'A message\n'
     }

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -18,7 +18,7 @@ describe('IPLD format util', () => {
     tagger: {
       name: 'John Doe',
       email: 'johndoe@example.com',
-      date: '1497302532 +0200'
+      date: '2017-06-12T23:22:12+02:00'
     },
     message: 'A message\n'
   }
@@ -29,7 +29,7 @@ describe('IPLD format util', () => {
       expect(Buffer.isBuffer(serialized)).to.equal(true)
       ipldGit.util.deserialize(serialized, (err, deserialized) => {
         expect(err).to.not.exist()
-        expect(tagNode).to.eql(deserialized)
+        expect(deserialized).to.eql(tagNode)
         done()
       })
     })


### PR DESCRIPTION
Related to ipfs/go-ipld-git#32. Use RFC3339 to format dates in JSON output.