### PR TITLE
fix: order tree directory entries correctly (fixes #44)

### DIFF
--- a/src/util/tree.js
+++ b/src/util/tree.js
@@ -11,7 +11,11 @@ exports.serialize = (dagNode, callback) => {
   Object.keys(dagNode).forEach((name) => {
     entries.push([name, dagNode[name]])
   })
-  entries.sort((a, b) => a[0] > b[0] ? 1 : -1)
+  entries.sort((a, b) => {
+    const aName = a[0] + (a[1].mode === '40000' ? '/' : '')
+    const bName = b[0] + (b[1].mode === '40000' ? '/' : '')
+    return aName > bName ? 1 : -1
+  })
   let buf = new SmartBuffer()
   entries.forEach((entry) => {
     buf.writeStringNT(entry[1].mode + ' ' + entry[0])

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -64,6 +64,14 @@ describe('IPLD format resolver (local)', () => {
         mode: '40000'
       }
     }
+    treeNode['somedir.notactuallyadir'] = {
+      hash: { '/': new CID('z8mWaJNVTadD7oum3m7f1dmarHvYhFV5b').buffer },
+      mode: '100644'
+    }
+    treeNode['somefile.notactuallyafile'] = {
+      hash: { '/': new CID('z8mWaFY1zpiZSXTBrz8i6A3o9vNvAs2CH').buffer },
+      mode: '40000'
+    }
 
     const blobNode = Buffer.from('626c6f62203800736f6d6564617461', 'hex') // blob 8\0somedata
 
@@ -228,12 +236,18 @@ describe('IPLD format resolver (local)', () => {
         expect(err).to.not.exist()
 
         expect(paths).to.eql([
+          'somedir.notactuallyadir',
+          'somedir.notactuallyadir/hash',
+          'somedir.notactuallyadir/mode',
           'somedir',
           'somedir/hash',
           'somedir/mode',
           'somefile',
           'somefile/hash',
-          'somefile/mode'
+          'somefile/mode',
+          'somefile.notactuallyafile',
+          'somefile.notactuallyafile/hash',
+          'somefile.notactuallyafile/mode'
         ])
 
         done()


### PR DESCRIPTION
Added a trailing / when entries are directories for sorting.
Two test entries are added similar to those in #44 to confirm the fix.