### PR TITLE
fix: multihashes does not export default lengths any more

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,15 +36,14 @@
   },
   "homepage": "https://github.com/ipld/js-ipld-git",
   "dependencies": {
-    "cids": "~0.8.0",
-    "multicodec": "^1.0.0",
-    "multihashes": "~0.4.14",
-    "multihashing-async": "~0.8.0",
-    "smart-buffer": "^4.0.2",
-    "strftime": "~0.10.0"
+    "cids": "^0.8.2",
+    "multicodec": "^1.0.2",
+    "multihashing-async": "^0.8.1",
+    "smart-buffer": "^4.1.0",
+    "strftime": "^0.10.0"
   },
   "devDependencies": {
-    "aegir": "^22.0.0",
+    "aegir": "^23.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "dirty-chai": "^2.0.1"

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const multihashes = require('multihashes/src/constants')
-const multihash = require('multihashes')
+const multihash = require('multihashing-async').multihash
 const CID = require('cids')
 const strftime = require('strftime')
 
 exports = module.exports
 
-exports.SHA1_LENGTH = multihashes.defaultLengths[multihashes.names.sha1]
+exports.SHA1_LENGTH = 20
 
 exports.find = (buf, byte) => {
   for (let i = 0; i < buf.length; i++) {

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -9,7 +9,7 @@ chai.use(chaiAsProised)
 chai.use(dirtyChai)
 const ipldGit = require('../src')
 const multicodec = require('multicodec')
-const multihash = require('multihashes')
+const multihash = require('multihashing-async').multihash
 const CID = require('cids')
 
 describe('IPLD format util', () => {


### PR DESCRIPTION
Since https://github.com/multiformats/js-multihash/pull/76 was released the `multihashes` module does not export default hash lengths any more.

For reasons that are not clear it went out as a patch release which means `ipld-git` is currently broken.

This PR hard codes the hash length as it is known, and also removes the `multihashes` dep as we can use the one exported from `multihashing-async`.

Ref: https://github.com/multiformats/js-multihash/pull/76#issuecomment-646561123