### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "multicodec": "^2.0.0",
     "multihashing-async": "^2.0.0",
     "smart-buffer": "^4.1.0",
-    "strftime": "^0.10.0"
+    "strftime": "^0.10.0",
+    "uint8arrays": "^1.0.0"
   },
   "devDependencies": {
     "aegir": "^25.0.0"

--- a/package.json
+++ b/package.json
@@ -37,17 +37,14 @@
   "homepage": "https://github.com/ipld/js-ipld-git",
   "dependencies": {
     "buffer": "^5.6.0",
-    "cids": "^0.8.3",
-    "multicodec": "^1.0.2",
-    "multihashing-async": "^1.0.0",
+    "cids": "^1.0.0",
+    "multicodec": "^2.0.0",
+    "multihashing-async": "^2.0.0",
     "smart-buffer": "^4.1.0",
     "strftime": "^0.10.0"
   },
   "devDependencies": {
-    "aegir": "^25.0.0",
-    "chai": "^4.2.0",
-    "chai-as-promised": "^7.1.1",
-    "dirty-chai": "^2.0.1"
+    "aegir": "^25.0.0"
   },
   "contributors": [
     "Volker Mische <volker.mische@gmail.com>",

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const CID = require('cids')
-const { Buffer } = require('buffer')
 
 const util = require('./util')
 
@@ -11,7 +10,7 @@ const util = require('./util')
  * Returns the value or a link and the partial mising path. This way the
  * IPLD Resolver can fetch the link and continue to resolve.
  *
- * @param {Buffer} binaryBlob - Binary representation of a Git block
+ * @param {Uint8Array} binaryBlob - Binary representation of a Git block
  * @param {string} [path='/'] - Path that should be resolved
  * @returns {Object} result - Result of the path it it was resolved successfully
  * @returns {*} result.value - Value the path resolves to
@@ -46,7 +45,7 @@ exports.resolve = (binaryBlob, path) => {
 
 const traverse = function * (node, path) {
   // Traverse only objects and arrays
-  if (Buffer.isBuffer(node) || CID.isCID(node) || typeof node === 'string' ||
+  if (node instanceof Uint8Array || CID.isCID(node) || typeof node === 'string' ||
       node === null) {
     return
   }
@@ -61,7 +60,7 @@ const traverse = function * (node, path) {
  * Return all available paths of a block.
  *
  * @generator
- * @param {Buffer} binaryBlob - Binary representation of a Bitcoin block
+ * @param {Uint8Array} binaryBlob - Binary representation of a Bitcoin block
  * @yields {string} - A single path
  */
 exports.tree = function * (binaryBlob) {

--- a/src/util.js
+++ b/src/util.js
@@ -20,14 +20,14 @@ exports.defaultHashAlg = multicodec.SHA1
  * Serialize internal representation into a binary Git block.
  *
  * @param {GitBlock} dagNode - Internal representation of a Git block
- * @returns {Buffer}
+ * @returns {Uint8Array}
  */
 exports.serialize = (dagNode) => {
   if (dagNode === null) {
     throw new Error('dagNode passed to serialize was null')
   }
 
-  if (Buffer.isBuffer(dagNode)) {
+  if (dagNode instanceof Uint8Array) {
     if (dagNode.slice(0, 4).toString() === 'blob') {
       return dagNode
     } else {
@@ -49,10 +49,14 @@ exports.serialize = (dagNode) => {
 /**
  * Deserialize Git block into the internal representation.
  *
- * @param {Buffer} data - Binary representation of a Git block.
+ * @param {Uint8Array} data - Binary representation of a Git block.
  * @returns {BitcoinBlock}
  */
 exports.deserialize = (data) => {
+  if (!Buffer.isBuffer(data)) {
+    data = Buffer.from(data, data.byteOffset, data.byteLength)
+  }
+
   const headLen = gitUtil.find(data, 0)
   const head = data.slice(0, headLen).toString()
   const typeLen = head.match(/([^ ]+) (\d+)/)

--- a/src/util.js
+++ b/src/util.js
@@ -4,6 +4,7 @@ const multihashing = require('multihashing-async')
 const CID = require('cids')
 const multicodec = require('multicodec')
 const { Buffer } = require('buffer')
+const uint8ArrayToString = require('uint8arrays/to-string')
 
 const gitUtil = require('./util/util')
 
@@ -28,7 +29,7 @@ exports.serialize = (dagNode) => {
   }
 
   if (dagNode instanceof Uint8Array) {
-    if (dagNode.slice(0, 4).toString() === 'blob') {
+    if (uint8ArrayToString(dagNode.slice(0, 4)) === 'blob') {
       return dagNode
     } else {
       throw new Error('unexpected dagNode passed to serialize')

--- a/test/mod.spec.js
+++ b/test/mod.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const multicodec = require('multicodec')
 
 const mod = require('../src')

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -3,10 +3,7 @@
 
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const { Buffer } = require('buffer')
 const loadFixture = require('aegir/fixtures')
 const zlib = require('zlib')

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -2,10 +2,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const { Buffer } = require('buffer')
 
 const CID = require('cids')

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -7,6 +7,7 @@ const multicodec = require('multicodec')
 const multihash = require('multihashing-async').multihash
 const CID = require('cids')
 const { Buffer } = require('buffer')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('IPLD format util', () => {
   const tagNode = {
@@ -23,6 +24,13 @@ describe('IPLD format util', () => {
   }
   const tagBlob = ipldGit.util.serialize(tagNode)
 
+  it('.serialize from Uint8Array', () => {
+    const node = uint8ArrayFromString('blob-blob')
+    const blob = ipldGit.util.serialize(node)
+
+    expect(blob).to.deep.equal(node)
+  })
+
   it('.serialize and .deserialize', () => {
     expect(Buffer.isBuffer(tagBlob)).to.be.true()
     const deserialized = ipldGit.util.deserialize(tagBlob)
@@ -35,8 +43,8 @@ describe('IPLD format util', () => {
   })
 
   it('.serialize and .deserialize Uint8Array', () => {
-    expect(Buffer.isBuffer(tagBlob)).to.be.true()
-    const deserialized = ipldGit.util.deserialize(Uint8Array.from(tagBlob))
+    expect(Buffer.isBuffer(Uint8Array.of(...tagBlob))).to.be.false()
+    const deserialized = ipldGit.util.deserialize(Uint8Array.of(...tagBlob))
 
     // The `gitType` is not enumerable, hence `eql()` would find it. Thus
     // remove that property so that that check passes

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -1,12 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const chaiAsProised = require('chai-as-promised')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(chaiAsProised)
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const ipldGit = require('../src')
 const multicodec = require('multicodec')
 const multihash = require('multihashing-async').multihash
@@ -31,6 +26,17 @@ describe('IPLD format util', () => {
   it('.serialize and .deserialize', () => {
     expect(Buffer.isBuffer(tagBlob)).to.be.true()
     const deserialized = ipldGit.util.deserialize(tagBlob)
+
+    // The `gitType` is not enumerable, hence `eql()` would find it. Thus
+    // remove that property so that that check passes
+    const expected = Object.assign({}, tagNode)
+    delete expected.gitType
+    expect(deserialized).to.eql(expected)
+  })
+
+  it('.serialize and .deserialize Uint8Array', () => {
+    expect(Buffer.isBuffer(tagBlob)).to.be.true()
+    const deserialized = ipldGit.util.deserialize(Uint8Array.from(tagBlob))
 
     // The `gitType` is not enumerable, hence `eql()` would find it. Thus
     // remove that property so that that check passes


### PR DESCRIPTION
This module now accepts Uint8Arrays as well as node Buffers and
returns Uint8Arrays.  Internally it converts non-Buffers into Buffers
because the ethereum libs require that.

BREAKING CHANGES:

- `util.cid` returns `CID`s with a breaking API change - see https://github.com/multiformats/js-cid/pull/117 for changes