### PR TITLE
fix: convert output of multihash.decode to buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "buffer": "^5.6.0",
     "cids": "^1.0.0",
     "multicodec": "^2.0.0",
-    "multihashing-async": "^2.0.0",
+    "multihashing-async": "^2.0.1",
     "smart-buffer": "^4.1.0",
     "strftime": "^0.10.0",
     "uint8arrays": "^1.0.0"

--- a/src/util.js
+++ b/src/util.js
@@ -55,7 +55,7 @@ exports.serialize = (dagNode) => {
  */
 exports.deserialize = (data) => {
   if (!Buffer.isBuffer(data)) {
-    data = Buffer.from(data, data.byteOffset, data.byteLength)
+    data = Buffer.from(data.buffer, data.byteOffset, data.byteLength)
   }
 
   const headLen = gitUtil.find(data, 0)

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -3,6 +3,7 @@
 const multihash = require('multihashing-async').multihash
 const CID = require('cids')
 const strftime = require('strftime')
+const { Buffer } = require('buffer')
 
 exports = module.exports
 
@@ -65,5 +66,5 @@ exports.cidToSha = (cid) => {
     return null
   }
 
-  return mh.digest
+  return Buffer.from(mh.digest.buffer, mh.digest.byteOffset, mh.digest.byteLength)
 }

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -31,6 +31,19 @@ describe('IPLD format util', () => {
     expect(blob).to.deep.equal(node)
   })
 
+  it('.serialize from tree', () => {
+    const node = {
+      'file.txt': {
+        hash: new CID('baf4bcfe5cqe5giojiciib5mci7gbb53xcxqot2i'),
+        mode: '644'
+      }
+    }
+    const blob = ipldGit.util.serialize(node)
+    const deserialized = ipldGit.util.deserialize(blob)
+
+    expect(deserialized).to.deep.equal(node)
+  })
+
   it('.serialize and .deserialize', () => {
     expect(Buffer.isBuffer(tagBlob)).to.be.true()
     const deserialized = ipldGit.util.deserialize(tagBlob)


### PR DESCRIPTION
The multihash module returns Uint8Arrays from it's decode method but
smart-buffer requires everything to be a buffer so convert the output.